### PR TITLE
Allow multiple expressions, fix imports, WIP interpreter

### DIFF
--- a/code/compiler/AbstractSyntax.fs
+++ b/code/compiler/AbstractSyntax.fs
@@ -19,3 +19,5 @@ type expr =
     | Function of string * string * expr list
     | Tuple of expr * expr
     | ADT of string * adtconstructor list
+
+type program = Program of expr list

--- a/code/compiler/AbstractSyntax.fs
+++ b/code/compiler/AbstractSyntax.fs
@@ -19,5 +19,4 @@ type expr =
     | Function of string * string * expr list
     | Tuple of expr * expr
     | ADT of string * adtconstructor list
-
-type program = Program of expr list
+    | Program of expr list

--- a/code/compiler/Interpreter.fs
+++ b/code/compiler/Interpreter.fs
@@ -1,0 +1,51 @@
+module Interpreter
+
+open AbstractSyntax
+
+type 'v env = (string * 'v) list
+
+let rec lookup env x =
+    match env with 
+    | []        -> failwith (x + " not found")
+    | (y, v)::r -> if x=y then v else lookup r x;;
+
+(* A runtime value is an integer or a function closure *)
+type value = 
+  | Integer of int
+  | Boolean of bool
+  | TupleVal of value * value
+  | Closure of string * string * expr * value env       (* (f, x, fBody, fDeclEnv) *)
+
+let rec eval (e: expr) (env : value env) : value =
+    match e with
+    | Program(x::xs) -> 
+        let xval = eval x env
+        if xs.IsEmpty then xval else eval (Program(xs)) env     // TODO: this just returns the last value in the program...
+    | ConstantInteger i -> Integer i
+    | Variable v -> lookup env v
+    | Let(name, expression) -> failwith "not implemented"
+    | Prim(operation, expression1, expression2) ->
+        let value1 = eval expression1 env
+        let value2 = eval expression2 env
+        match (value1, value2) with 
+        | ((Integer(v1)), Integer(v2)) -> 
+            match (operation) with
+            | ("+") -> Integer(v1 + v2)
+            | ("-") -> Integer(v1 - v2)
+            | ("*") -> Integer(v1 - v2)
+            | ("/") -> Integer(v1 / v2)
+            | ("%") -> Integer(v1 % v2)
+            | (">") -> Boolean(v1 > v2)
+            | (">=") -> Boolean(v1 >= v2)
+            | ("<") -> Boolean(v1 < v2)
+            | ("<=") -> Boolean(v1 <= v2)
+            | ("==") -> Boolean(v1 = v2)
+            | ("!=") -> Boolean(v1 <> v2)
+            | _ -> failwithf "%s is not a valid operation on integers" operation
+        | _ -> failwith "Sorry, can only operate on integers"
+    | Function(name, parameter, expressions) -> failwith "not implemented"
+    | Tuple(expression1, expression2) ->
+        let value1 = eval expression1 env
+        let value2 = eval expression2 env
+        TupleVal (value1, value2)
+    | ADT(adtName, (constructors: adtconstructor list)) -> failwith "not implemented"

--- a/code/compiler/Lexer.fsl
+++ b/code/compiler/Lexer.fsl
@@ -27,7 +27,7 @@ let keyword s =
 
 rule Token = parse
   | [' ' '\r' '\t'] { Token lexbuf }
-  | '\n'            { NEWLINE }
+  | '\n'            { lexbuf.EndPos <- lexbuf.EndPos.NextLine; NEWLINE }
   | ['0'-'9']+      { CONSTINT (System.Int32.Parse (lexemeAsString lexbuf)) }
   | ['a'-'z''A'-'Z']['a'-'z''A'-'Z''0'-'9']*  { keyword (lexemeAsString lexbuf) }
   | '+'             { PLUS }

--- a/code/compiler/Makefile
+++ b/code/compiler/Makefile
@@ -18,7 +18,7 @@ run:
 	@echo " -- STARTING INTERACTIVE --"
 	@echo ""
 	fsharpi -r ~/fsharp/FsLexYacc.Runtime.dll --consolecolors --lib:$(shell pwd)/generated/ \
-		AbstractSyntax.fs Transpiler.fs Parser.fs Lexer.fs Program.fs
+		AbstractSyntax.fs Transpiler.fs Parser.fs Lexer.fs Interpreter.fs Program.fs
 
 setup:
 	# This setup is based on this guide: https://gist.github.com/AndreasHassing/16567f299b77b0090d94441115a5d031/ae1db7572fd877df733213120800084fbafe9858#5-link-the-runtime-dll-to-your-fsharp-folder

--- a/code/compiler/Parser.fsy
+++ b/code/compiler/Parser.fsy
@@ -44,9 +44,8 @@
 %nonassoc NOT
 
 %start Main
-%type <AbstractSyntax.expr> Value Expr Exp ADT Assignment FuncDef
+%type <AbstractSyntax.expr> Main Value Expr Exp ADT Assignment FuncDef
 %type <AbstractSyntax.types> TypeSpec
-%type <AbstractSyntax.program> Main Program
 %%
 
 Main:

--- a/code/compiler/Parser.fsy
+++ b/code/compiler/Parser.fsy
@@ -60,6 +60,7 @@ Declaration:
   | Assignment          { $1 }
   | FuncDef             { $1 }
   | ADT                 { $1 }
+  | NEWLINE Declaration { $2 }    // handles empty lines
 
 // Stmt: 
 // | NAME ASSIGN Expr NEWLINE { Let($1, $3) }
@@ -67,6 +68,7 @@ Declaration:
 
 DeclarationList:
   | Declaration                          { [$1] }
+  | Declaration NEWLINE                  { [$1] }   // handles newlines at end of file
   | Declaration NEWLINE DeclarationList  { $1 :: $3 }
 
 Value:

--- a/code/compiler/Parser.fsy
+++ b/code/compiler/Parser.fsy
@@ -44,35 +44,36 @@
 %nonassoc NOT
 
 %start Main
-%type <AbstractSyntax.expr> Main Program Value Expr ADT Assignment FuncDef
+%type <AbstractSyntax.expr> Value Expr Exp ADT Assignment FuncDef
 %type <AbstractSyntax.types> TypeSpec
-%type <AbstractSyntax.adtconstructor>
+%type <AbstractSyntax.program> Main Program
 %%
 
 Main:
     Program EOF { $1 }
 ;
 
-Program:
-    Expr       { $1 }
-  | Assignment { $1 }
-  | FuncDef    { $1 }
-  | ADT        { $1 }
+Program: DeclarationList  { Program( $1 ) }
+
+Declaration:
+  | Expr                { $1 }
+  | Assignment          { $1 }
+  | FuncDef             { $1 }
+  | ADT                 { $1 }
+
+// Stmt: 
+// | NAME ASSIGN Expr NEWLINE { Let($1, $3) }
+// | BEGIN StmtList END { Seq(List.rev($2)) }    I want this one :'(
+
+DeclarationList:
+  | Declaration                          { [$1] }
+  | Declaration NEWLINE DeclarationList  { $1 :: $3 }
 
 Value:
     CONSTINT                    { ConstantInteger $1 }
   | CONSTBOOL                   { ConstantBoolean $1 }
   | NAME                        { Variable $1 }
   | LPAR Value COMMA Value RPAR { Tuple($2, $4) }
-
-Expr:
-  | Exp NOTEQL Exp  { Prim("!=", $1, $3) }
-  | Exp EQL    Exp  { Prim("==", $1, $3) }
-  | Exp GT     Exp  { Prim(">",  $1, $3) }
-  | Exp LT     Exp  { Prim("<",  $1, $3) }
-  | Exp GE     Exp  { Prim(">=", $1, $3) }
-  | Exp LE     Exp  { Prim("<=", $1, $3) }
-  | Exp             { $1 }
 
 Exp:
   | Value           { $1                 }
@@ -84,20 +85,25 @@ Exp:
   | Exp MOD   Exp   { Prim("%", $1, $3)  }
   | LPAR Expr RPAR  { $2 }
 
-Assignment:
-    NAME ASSIGN Expr NEWLINE { Let($1, $3) }
-  | ADT NEWLINE              { $1 }
+Expr:
+  | Exp NOTEQL Exp  { Prim("!=", $1, $3) }
+  | Exp EQL    Exp  { Prim("==", $1, $3) }
+  | Exp GT     Exp  { Prim(">",  $1, $3) }
+  | Exp LT     Exp  { Prim("<",  $1, $3) }
+  | Exp GE     Exp  { Prim(">=", $1, $3) }
+  | Exp LE     Exp  { Prim("<=", $1, $3) }
+  | Exp             { $1 }
+
+Assignment: NAME ASSIGN Expr                       { Let($1, $3) }
 
 ExprList:
-    Expr NEWLINE          { [$1] }
-  | NEWLINE ExprListInner { $2 }
-
-ExprListInner:
-    Expr NEWLINE END           { [$1] }
-  | Expr NEWLINE ExprListInner { $1 :: $3 }
+  | Expr NEWLINE                    { [$1] }
+  | Assignment NEWLINE ExprList END { $1 :: $3 }
+  | FuncDef ExprList END            { $1 :: $2 }
 
 FuncDef:
-  FUNCTION NAME NAME ASSIGN ExprList { Function($2, $3, $5 ) }
+  | FUNCTION NAME NAME ASSIGN Expr                    { Function($2, $3, [$5] ) }
+  | FUNCTION NAME NAME ASSIGN NEWLINE ExprList        { Function($2, $3, $6 ) }
 
 // ====== ADT grammar rules: =======
 ADT:

--- a/code/compiler/Parser.fsy
+++ b/code/compiler/Parser.fsy
@@ -114,6 +114,16 @@ ADTSimpleConstructor:
 ADTCompoundConstructor:
     NEWLINE ADTSimpleConstructor { $2 }
 
+// ADTSimpleConstructor:
+//     NAME ADTConstructorParameter                    { [adtconstructor($1, $2)] }
+//   | NAME ADTConstructorParameter PIPE ADTSimpleConstructor { adtconstructor($1, $2)::$4 }
+//   | NAME ADTConstructorParameter NEWLINE PIPE ADTSimpleConstructor { adtconstructor($1, $2)::$5 }
+
+// ADTCompoundConstructor:
+//     NEWLINE ADTSimpleConstructor { $2 }
+//   | PIPE ADTSimpleConstructor { $2 }
+//   | NEWLINE PIPE ADTSimpleConstructor { $3 }
+
 ADTConstructorParameter:
   | /* empty */                      { [] }
   | TypeSpec ADTConstructorParameter { $1::$2 }

--- a/code/compiler/Program.fs
+++ b/code/compiler/Program.fs
@@ -1,4 +1,4 @@
-﻿module Program
+module Program
 
 open System
 open FSharp.Text.Lexing
@@ -8,7 +8,7 @@ open Transpiler
 open Lexer
 open Parser
 
-let fromString (str: string): expr =
+let fromString (str: string): program =
     let lexbuf = LexBuffer<char>.FromString(str)
     try
         Parser.Main Lexer.Token lexbuf
@@ -20,6 +20,17 @@ let src = """
         Ctor1
       | Ctor2 Integerx
 """
+
+let test = """x = 2
+y = 3
+func f x = x+y
+
+func f x =
+    x = 2
+    x
+end 
+
+type DisjointSum = Ctor1 | Ctor2 Integer"""
 
 [<EntryPoint>]
 let main argv =

--- a/code/compiler/Program.fs
+++ b/code/compiler/Program.fs
@@ -7,17 +7,26 @@ open AbstractSyntax
 open Transpiler
 open Lexer
 open Parser
+open Interpreter
 
 exception SyntaxError of int * int
     with override this.Message = sprintf "Syntax error at line %d, column %d." this.Data0 this.Data1
 
-let fromString (str: string): program =
+let fromString (str: string): expr =
     let lexbuf = LexBuffer<char>.FromString(str)
     try
         Parser.Main Lexer.Token lexbuf
     with 
       | Failure ("parse error")     -> raise <| SyntaxError ((lexbuf.EndPos.Line+1) , lexbuf.EndPos.Column)
       | _                           -> reraise ()
+
+let evalString (str: string): value =
+    eval (fromString str) []
+
+let testEval = """
+3 + 4
+7 == 9
+"""
 
 let src = """
  type DisjointSum =

--- a/code/compiler/compiler2.fsproj
+++ b/code/compiler/compiler2.fsproj
@@ -6,8 +6,10 @@
   <ItemGroup>
     <Compile Include="AbstractSyntax.fs" />
     <Compile Include="Transpiler.fs" />
-    <Compile Include="Parser.fs" />
-    <Compile Include="Lexer.fs" />
+    <Compile Include="./generated/Parser.fsi" />
+    <Compile Include="./generated/Parser.fs" />
+    <Compile Include="./generated/Lexer.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
+  
 </Project>

--- a/code/compiler/compiler2.fsproj
+++ b/code/compiler/compiler2.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="./generated/Parser.fsi" />
     <Compile Include="./generated/Parser.fs" />
     <Compile Include="./generated/Lexer.fs" />
+    <Compile Include="Interpreter.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   


### PR DESCRIPTION
Changed program to have multiple expressions (list), but i would like your review on this implementation.

Also, the newline tokens are polluting the parser quite a bit i think, but maybe we can do it better than i did here.

I'm having some troubles with the current ADT parser. I've implemented a version that can handle almost every way of defining an ADT (with or without newlines, and with or without pipes before the first constructor) but I only added it as a comment below the original version, as the code is quite ugly..

Started implementing an interpreter (evaluator). It currently handles only primitive operations, so it can evaluate programs like "2+2".

Added error reporting for parsing.

Fixed import errors.